### PR TITLE
Fix Gemini audio MIME type

### DIFF
--- a/firebase-functions/index.js
+++ b/firebase-functions/index.js
@@ -719,6 +719,7 @@ exports.analyzeLongAudioWithGemini = functions
   .https.onCall(async (data, context) => {
     try {
       const { audioBase64, audioType = 'audio/webm', analysisType = 'transcription' } = data;
+      const mimeType = (audioType || 'audio/webm').split(';')[0];
       
       if (!audioBase64) {
         throw new functions.https.HttpsError('invalid-argument', 'Audio base64 requis');
@@ -732,7 +733,7 @@ exports.analyzeLongAudioWithGemini = functions
       }
 
       console.log('=== ANALYSE AUDIO LONGUE AVEC GEMINI ===');
-      console.log(`Type audio: ${audioType}`);
+      console.log(`Type audio: ${mimeType}`);
       console.log(`Type d'analyse: ${analysisType}`);
       
       // Extraire les données base64 (enlever le préfixe data:audio/...;base64,)
@@ -842,15 +843,16 @@ Format : Transcription complète suivie de l'analyse structurée pour le médeci
       // Appeler l'API Gemini
       const response = await axios.post(
         `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GOOGLE_API_KEY}`,
-        {
+        { 
           contents: [{
+            role: 'user',
             parts: [
               {
                 text: prompt
               },
               {
                 inline_data: {
-                  mime_type: audioType,
+                  mime_type: mimeType,
                   data: base64Data
                 }
               }

--- a/src/services/ai-client.ts
+++ b/src/services/ai-client.ts
@@ -1309,7 +1309,7 @@ IMPORTANT: Retourne UNIQUEMENT le JSON, sans texte avant ou après.`;
         const analyzeLongAudioWithGemini = httpsCallable(functions, 'analyzeLongAudioWithGemini');
         const result = await analyzeLongAudioWithGemini({
           audioBase64,
-          audioType: audioBlob.type || 'audio/webm',
+          audioType: (audioBlob.type || 'audio/webm').split(';')[0],
           analysisType
         });
         
@@ -1341,15 +1341,18 @@ IMPORTANT: Retourne UNIQUEMENT le JSON, sans texte avant ou après.`;
             break;
         }
         
+        const mimeType = (audioBlob.type || 'audio/webm').split(';')[0];
+
         const response = await axios.post(
           `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GOOGLE_API_KEY}`,
           {
             contents: [{
+              role: 'user',
               parts: [
                 { text: prompt },
                 {
                   inline_data: {
-                    mime_type: audioBlob.type || 'audio/webm',
+                    mime_type: mimeType,
                     data: base64Data
                   }
                 }


### PR DESCRIPTION
## Summary
- sanitize the audio MIME type before sending requests to Gemini

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c492def30832891c8a5781cf8524d